### PR TITLE
Update compatibility with 1.4

### DIFF
--- a/includes/PSEditSchemaAction.php
+++ b/includes/PSEditSchemaAction.php
@@ -28,7 +28,7 @@ class PSEditSchemaAction extends Action {
 	 * @return bool
 	 */
 	public function show() {
-		$title = $this->page->getTitle();
+		$title = $this->getWikiPage()->getTitle();
 
 		// These tabs should only exist for category pages
 		if ( $title->getNamespace() != NS_CATEGORY ) {

--- a/includes/PSGeneratePagesAction.php
+++ b/includes/PSGeneratePagesAction.php
@@ -25,7 +25,7 @@ class PSGeneratePagesAction extends Action {
 	 * @return bool
 	 */
 	public function show() {
-		$title = $this->page->getTitle();
+		$title = $this->getWikiPage()->getTitle();
 
 		// These tabs should only exist for category pages
 		if ( $title->getNamespace() != NS_CATEGORY ) {


### PR DESCRIPTION
$this->page inherited from action.php is deprecated since 1.35 and removed in 1.40
Changed for $this->getWikiPage() in two files to restore compatibility with 1.4x